### PR TITLE
Add breadcrumbs to ServicePack pages

### DIFF
--- a/app/controllers/service_packs_controller.rb
+++ b/app/controllers/service_packs_controller.rb
@@ -62,6 +62,11 @@ class ServicePacksController < ApplicationController
     end
   end
 
+  # The string with the minus sign in front is a shorthand for <string>.freeze
+  # reducing server processing time (and testing time) by 30%!
+  # Freezing a string literal will stop it from being created anew over and over.
+  # All literal strings will be frozen in Ruby 3 by default, which is a good idea.
+
   def create
     mapping_rate_attribute = params[:service_pack][:mapping_rates_attributes]
     # binding.pry
@@ -146,7 +151,7 @@ class ServicePacksController < ApplicationController
   end
 
   def default_breadcrumb
-    action_name == 'index'? 'Service Packs' : ActionController::Base.helpers.link_to('Service Packs', service_packs_path)
+    action_name == 'index'? -'Service Packs' : ActionController::Base.helpers.link_to(-'Service Packs', service_packs_path)
   end
 
   # =======================================================

--- a/app/controllers/service_packs_controller.rb
+++ b/app/controllers/service_packs_controller.rb
@@ -57,14 +57,14 @@ class ServicePacksController < ApplicationController
             ORDER BY spent_on DESC
             SQL
         entries = ActiveRecord::Base.connection.exec_query(sql).to_hash
-        render csv: csv_extractor(entries), filename: "service_pack_#{@service_pack.id}.csv"
+        render csv: csv_extractor(entries), filename: "service_pack_#{@service_pack.name}.csv"
       }
     end
   end
 
   def create
     mapping_rate_attribute = params[:service_pack][:mapping_rates_attributes]
-    binding.pry
+    # binding.pry
     activity_id = []
     mapping_rate_attribute.each {|_index, hash_value| activity_id.push(hash_value[:activity_id])}
 
@@ -140,6 +140,14 @@ class ServicePacksController < ApplicationController
     redirect_to service_packs_path
   end
 
+  # for breadcrumb code
+  def show_local_breadcrumb
+    true
+  end
+
+  def default_breadcrumb
+    action_name == 'index'? 'Service Packs' : ActionController::Base.helpers.link_to('Service Packs', service_packs_path)
+  end
 
   # =======================================================
   # :Docs

--- a/app/views/service_packs/edit.html.erb
+++ b/app/views/service_packs/edit.html.erb
@@ -1,5 +1,8 @@
 <%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
 
+<% local_assigns[:additional_breadcrumb] = @sp.name %>
+<% html_title l(:label_administration), 'Edit Service Pack' %>
+
 <h2> <%= @sp.name %> </h2>
 
 <%= form_for @sp, local: true do |form| %>

--- a/app/views/service_packs/edit.html.erb
+++ b/app/views/service_packs/edit.html.erb
@@ -1,7 +1,7 @@
-<%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
+<%= stylesheet_link_tag -'service_packs', plugin: :openproject_service_packs %>
 
 <% local_assigns[:additional_breadcrumb] = @sp.name %>
-<% html_title l(:label_administration), 'Edit Service Pack' %>
+<% html_title l(:label_administration), -'Edit Service Pack' %>
 
 <h2> <%= @sp.name %> </h2>
 

--- a/app/views/service_packs/index.html.erb
+++ b/app/views/service_packs/index.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
 
-<% html_title l(:label_administration), t(:service_packs) %>
+<% html_title l(:label_administration), 'Service Packs'.freeze %>
 
 <%= link_to 'New', new_service_pack_path, class: "button -alt-highlight" %>
 
@@ -10,11 +10,11 @@
     <th>Name</th>
     <th>Total Units</th>
     <th>Remained Units</th>
-	<th>Started Date</th>
-	<th>End Date</th>
-	<th>Threshold 1</th>
-	<th>Threshold 2</th>
-	<th>Assigned</th>	    
+    <th>Started Date</th>
+    <th>End Date</th>
+    <th>Threshold 1</th>
+    <th>Threshold 2</th>
+    <th>Assigned</th>	    
   </tr>
  
   <% @service_packs.find_each do |sp| %>

--- a/app/views/service_packs/index.html.erb
+++ b/app/views/service_packs/index.html.erb
@@ -1,6 +1,6 @@
-<%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
+<%= stylesheet_link_tag -'service_packs', plugin: :openproject_service_packs %>
 
-<% html_title l(:label_administration), 'Service Packs'.freeze %>
+<% html_title l(:label_administration), -'Service Packs' %>
 
 <%= link_to 'New', new_service_pack_path, class: "button -alt-highlight" %>
 

--- a/app/views/service_packs/new.html.erb
+++ b/app/views/service_packs/new.html.erb
@@ -1,8 +1,8 @@
-<%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
+<%= stylesheet_link_tag -'service_packs', plugin: :openproject_service_packs %>
 
-<% html_title l(:label_administration), 'Create Service Pack'.freeze %>
-<% local_assigns[:additional_breadcrumb] = 'Create Service Pack' %>
+<% html_title l(:label_administration), -'Create Service Pack' %>
+<% local_assigns[:additional_breadcrumb] = -'Create Service Pack' %>
 
 <%= render 'form' %>
 
-<%= link_to "Back", service_packs_path, class: "button -alt-highlight" %>
+<%= link_to "Back", service_packs_path, class: -"button -alt-highlight" %>

--- a/app/views/service_packs/new.html.erb
+++ b/app/views/service_packs/new.html.erb
@@ -1,9 +1,8 @@
 <%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
 
-<h1>
-  Create New Service Pack
-</h1>
+<% html_title l(:label_administration), 'Create Service Pack'.freeze %>
+<% local_assigns[:additional_breadcrumb] = 'Create Service Pack' %>
 
 <%= render 'form' %>
 
-<%= link_to "Back", service_packs_path, :class => "button -alt-highlight" %>
+<%= link_to "Back", service_packs_path, class: "button -alt-highlight" %>

--- a/app/views/service_packs/show.html.erb
+++ b/app/views/service_packs/show.html.erb
@@ -1,6 +1,9 @@
 <%= javascript_include_tag 'service_packs.js', plugin: :openproject_service_packs %>
 <%= stylesheet_link_tag 'service_packs', plugin: :openproject_service_packs %>
 
+<% local_assigns[:additional_breadcrumb] = @service_pack.name %>
+<% html_title l(:label_administration), @service_pack.name %>
+
 <h2><%= @service_pack.name %></h2>
 
 <!-- this can be improved, less thick border, a bit more line-height and stuff -->


### PR DESCRIPTION
Breadcrumbs are used to help users to know which page they are on the site. This patch uses the OP built-in admin breadcrumb.

![Breadcrumb on SP](http://images2.imagebam.com/ad/27/e3/a385911133728954.png)
![Breadcrumb on Index](http://images2.imagebam.com/52/4d/ab/f8e7331133734104.png)
